### PR TITLE
Fix package insertion point for java7

### DIFF
--- a/src/org/umlgraph/doclet/UmlGraphDoc.java
+++ b/src/org/umlgraph/doclet/UmlGraphDoc.java
@@ -98,7 +98,7 @@ public class UmlGraphDoc {
     	    UmlGraph.buildGraph(root, view, packageDoc);
     	    runGraphviz(opt.dotExecutable, outputFolder, packageDoc.name(), packageDoc.name(), root);
     	    alterHtmlDocs(opt, outputFolder, packageDoc.name(), packageDoc.name(),
-    		    "package-summary.html", Pattern.compile(".*</[Hh]2>.*"), root);
+    		    "package-summary.html", Pattern.compile("(</[Hh]2>)|(<h1 title=\"Package\").*"), root);
 	    }
 	}
     }


### PR DESCRIPTION
This patch fixes the insertion point for package grapths in java7
