### PR TITLE
[squid:S1161] "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/org/umlgraph/doclet/ContextMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/ContextMatcher.java
@@ -168,6 +168,8 @@ public class ContextMatcher implements ClassMatcher {
 	    prologue();
 	}
 
+	@Override
+	@Override
 	public void prologue() throws IOException {
 	    w = new PrintWriter(new DevNullWriter());
 	}
@@ -180,14 +182,17 @@ public class ContextMatcher implements ClassMatcher {
      */
     private static class DevNullWriter extends Writer {
 
+	@Override
 	public void write(char[] cbuf, int off, int len) throws IOException {
 	    // nothing to do
 	}
 
+	@Override
 	public void flush() throws IOException {
 	    // nothing to do
 	}
 
+	@Override
 	public void close() throws IOException {
 	    // nothing to do
 	}

--- a/src/main/java/org/umlgraph/doclet/Options.java
+++ b/src/main/java/org/umlgraph/doclet/Options.java
@@ -189,7 +189,8 @@ public class Options implements Cloneable, OptionProvider {
     dotExecutable = "dot";
     }
 
-    public Object clone() {
+    @Override
+	public Object clone() {
 	Options clone = null;
 	try {
 	     clone = (Options) super.clone();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - “ "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.
Ayman Abdelghany.