### PR TITLE
Workaround for graphviz crash bug

### DIFF
--- a/src/main/java/org/umlgraph/doclet/Shape.java
+++ b/src/main/java/org/umlgraph/doclet/Shape.java
@@ -79,10 +79,10 @@ public class Shape {
 
     /** Return the shape's GraphViz landing port */
     String landingPort() {
-	if (name.equals("class") || name.equals("activeclass"))
-	    return ":p";
-	else
-	    return "";
+	// if (name.equals("class") || name.equals("activeclass"))
+	//    return ":p";
+	//else
+	return "";
     }
 
     /** Return the table border required for the shape */


### PR DESCRIPTION
This seemingly trivial change appears to avoid the graphviz crash bug.
But I don't know if this sometimes will produce less pretty plots.