### PR TITLE
Strip generics from parent classes properly, fixes #20

### DIFF
--- a/src/main/java/org/umlgraph/doclet/ClassGraph.java
+++ b/src/main/java/org/umlgraph/doclet/ClassGraph.java
@@ -1013,8 +1013,17 @@ class ClassGraph {
 	int openIdx = name.indexOf('<');
 	if(openIdx == -1)
 	    return name;
-	else
-	    return name.substring(0, openIdx);
+	StringBuilder buf = new StringBuilder(name.length());
+	for (int i = 0, depth = 0; i < name.length(); i++) {
+		char c = name.charAt(i);
+		if (c == '<')
+			depth++;
+		else if (c == '>')
+			depth--;
+		else if (depth == 0)
+			buf.append(c);
+	}
+	return buf.toString();
     }
 
     /** Convert the class name into a corresponding URL */


### PR DESCRIPTION
Fixes the handling of non-static inner classes `Parent<A>.Child` if the parent has generics, #20