### PR TITLE
Add an @opt include option for the package view.

### DIFF
--- a/doc/cd-opt.xml
+++ b/doc/cd-opt.xml
@@ -27,6 +27,9 @@ be specified through javadoc tags within the diagram, affecting all or some elem
  in this case it will hide everything (useful in the context of views
  to selectively unhide some portions of the graph, see the view chapter for
  further details).  </dd>
+<dt>-include</dt><dd>Match classes to include with a non-anchored match. This is weaker than
+ the <code>-hide</code> option, but can be used to include classes from foreign packages
+ in the package view (which would by default filter to only include package members).</dd>
 <dt>-operations</dt><dd>Show class operations (Java methods) </dd>
 <dt>-qualify</dt><dd>Produce fully-qualified class names.  </dd>
 <dt>-types</dt><dd>Add type information to attributes and operations </dd>

--- a/doc/ver.xml
+++ b/doc/ver.xml
@@ -3,6 +3,11 @@
 <dl>
 
 <dt>Version 5.7 Under development </dt><dd>
+<ul>
+<li>The <code>@opt include</code> option can be used to include classes from
+foreign packages in the package view (unless hidden with <code>@opt hide</code>).</li>
+<li>You can now also use <code>@opt</code> in <code>package-info.java</code>.</li>
+</ul>
 </dd>
 
 <dt>Version 5.6 2012-05-31 </dt><dd>

--- a/src/main/java/org/umlgraph/doclet/ContextView.java
+++ b/src/main/java/org/umlgraph/doclet/ContextView.java
@@ -74,8 +74,9 @@ public class ContextView implements OptionProvider {
     }
 
     public Options getOptionsFor(ClassDoc cd) {
-    Options opt;
-	if (globalOptions.matchesHideExpression(cd.toString()) || !matcher.matches(cd)) {
+	Options opt;
+	if (globalOptions.matchesHideExpression(cd.qualifiedName())
+		|| !(matcher.matches(cd) || globalOptions.matchesIncludeExpression(cd.qualifiedName()))) {
 		opt = hideOptions;
 	} else if (cd.equals(this.cd)) {
 		opt = centerOptions;
@@ -103,15 +104,16 @@ public class ContextView implements OptionProvider {
     }
 
     public void overrideForClass(Options opt, ClassDoc cd) {
-    	opt.setOptions(cd);
-	if (opt.matchesHideExpression(cd.toString()) || !matcher.matches(cd))
+	opt.setOptions(cd);
+	if (opt.matchesHideExpression(cd.qualifiedName())
+		|| !(matcher.matches(cd) || opt.matchesIncludeExpression(cd.qualifiedName())))
 	    opt.setOption(HIDE_OPTIONS);
 	if (cd.equals(this.cd))
 	    opt.nodeFillColor = "lemonChiffon";
     }
 
     public void overrideForClass(Options opt, String className) {
-	if (!matcher.matches(className))
+	if (!(matcher.matches(className) || opt.matchesIncludeExpression(className)))
 	    opt.setOption(HIDE_OPTIONS);
     }
 

--- a/src/main/java/org/umlgraph/doclet/PackageView.java
+++ b/src/main/java/org/umlgraph/doclet/PackageView.java
@@ -17,15 +17,19 @@ import com.sun.javadoc.RootDoc;
  */
 public class PackageView implements OptionProvider {
 
+    private static final String[] HIDE = new String[] { "-hide" };
     private PackageDoc pd;
     private OptionProvider parent;
     private ClassMatcher matcher;
     private String outputPath;
+    private Options opt;
 
     public PackageView(String outputFolder, PackageDoc pd, RootDoc root, OptionProvider parent) {
 	this.parent = parent;
 	this.pd = pd;
 	this.matcher = new PackageMatcher(pd);
+	this.opt = parent.getGlobalOptions();
+	this.opt.setOptions(pd);
 	this.outputPath = pd.name().replace('.', '/') + "/" + pd.name() + ".dot";
     }
 
@@ -37,7 +41,7 @@ public class PackageView implements OptionProvider {
 	Options go = parent.getGlobalOptions();
 
 	go.setOption(new String[] { "-output", outputPath });
-	go.setOption(new String[] { "-hide" });
+	go.setOption(HIDE);
 
 	return go;
     }
@@ -56,15 +60,22 @@ public class PackageView implements OptionProvider {
 
     public void overrideForClass(Options opt, ClassDoc cd) {
 	opt.setOptions(cd);
-	opt.showQualified = false;
-	if (!matcher.matches(cd) || parent.getGlobalOptions().matchesHideExpression(cd.name()))
-	    opt.setOption(new String[] { "-hide" });
+	boolean inPackage = matcher.matches(cd);
+	if (inPackage)
+	    opt.showQualified = false;
+	if (!(inPackage || this.opt.matchesIncludeExpression(cd.qualifiedName()))
+		|| this.opt.matchesHideExpression(cd.qualifiedName()))
+	    opt.setOption(HIDE);
     }
 
     public void overrideForClass(Options opt, String className) {
 	opt.showQualified = false;
-	if (!matcher.matches(className))
-	    opt.setOption(new String[] { "-hide" });
+	boolean inPackage = matcher.matches(className);
+	if (inPackage)
+	    opt.showQualified = false;
+	if (!(inPackage || this.opt.matchesIncludeExpression(className))
+		|| this.opt.matchesHideExpression(className))
+	    opt.setOption(HIDE);
     }
 
 }


### PR DESCRIPTION
The idea is to allow adding `@opt include otherpackage.ImportantInterface` to a `package-info.java` for better package views. I'm not sure if this will also be useful for other views.

Apparently, `@opt` didn't work in package-info.java (for package views) at all. Now it does; so you can also use this to hide elements there.