### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/org/umlgraph/doclet/ClassGraph.java
+++ b/src/main/java/org/umlgraph/doclet/ClassGraph.java
@@ -82,7 +82,7 @@ class ClassGraph {
 
     protected Map<String, ClassInfo> classnames = new HashMap<String, ClassInfo>();
     protected Set<String> rootClasses;
-	protected Map<String, ClassDoc> rootClassdocs = new HashMap<String, ClassDoc>();
+    protected Map<String, ClassDoc> rootClassdocs = new HashMap<String, ClassDoc>();
     protected OptionProvider optionProvider;
     protected PrintWriter w;
     protected ClassDoc collectionClassDoc;
@@ -673,7 +673,8 @@ class ClassGraph {
 	}
     }
 
-    /** Returns an array representing the imported classes of c.
+    /**
+     * Returns an array representing the imported classes of c.
      * Disables the deprecation warning, which is output, because the
      * imported classed are an implementation detail.
      */
@@ -848,8 +849,10 @@ class ClassGraph {
 		.append(".html").toString();
     }
 
-    /** Dot prologue 
-     * @throws IOException */
+    /**
+     * Dot prologue 
+     * @throws IOException
+     */
     public void prologue() throws IOException {
 	Options opt = optionProvider.getGlobalOptions();
 	OutputStream os;

--- a/src/main/java/org/umlgraph/doclet/ClassGraph.java
+++ b/src/main/java/org/umlgraph/doclet/ClassGraph.java
@@ -200,7 +200,7 @@ class ClassGraph {
     private String typeParameters(Options opt, ParameterizedType t) {
 	if (t == null)
 	    return "";
-	StringBuffer tp = new StringBuffer(1000).append("&lt;");
+	StringBuilder tp = new StringBuilder(1000).append("&lt;");
 	Type args[] = t.typeArguments();
 	for (int i = 0; i < args.length; i++) {
 	    tp.append(type(opt, args[i], true));
@@ -439,7 +439,7 @@ class ClassGraph {
 		if (ecs.length == 0) {
 		    tableLine(Align.LEFT, "");
 		} else {
-		    for (FieldDoc fd : c.enumConstants()) {
+		    for (FieldDoc fd : ecs) {
 			tableLine(Align.LEFT, fd.name());
 		    }
 		}

--- a/src/main/java/org/umlgraph/doclet/ClassInfo.java
+++ b/src/main/java/org/umlgraph/doclet/ClassInfo.java
@@ -66,7 +66,5 @@ class ClassInfo {
     public static void reset() {
 	classNumber = 0;
     }
-
-    
 }
 

--- a/src/main/java/org/umlgraph/doclet/ContextMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/ContextMatcher.java
@@ -192,5 +192,4 @@ public class ContextMatcher implements ClassMatcher {
 	}
 
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/ContextView.java
+++ b/src/main/java/org/umlgraph/doclet/ContextView.java
@@ -116,5 +116,4 @@ public class ContextView implements OptionProvider {
 	if (!(matcher.matches(className) || opt.matchesIncludeExpression(className)))
 	    opt.setOption(HIDE_OPTIONS);
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/InterfaceMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/InterfaceMatcher.java
@@ -38,5 +38,4 @@ public class InterfaceMatcher implements ClassMatcher {
 	ClassDoc cd = root.classNamed(name);
 	return cd == null ? false : matches(cd);
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/Options.java
+++ b/src/main/java/org/umlgraph/doclet/Options.java
@@ -130,7 +130,7 @@ public class Options implements Cloneable, OptionProvider {
     }
 
     @Override
-	public Object clone() {
+    public Object clone() {
 	Options clone = null;
 	try {
 	     clone = (Options) super.clone();
@@ -680,5 +680,4 @@ public class Options implements Cloneable, OptionProvider {
 	}
 	return sb.toString();
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/PackageMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/PackageMatcher.java
@@ -20,5 +20,4 @@ public class PackageMatcher implements ClassMatcher {
 		return true;
 	return false;
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/PackageMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/PackageMatcher.java
@@ -7,7 +7,6 @@ public class PackageMatcher implements ClassMatcher {
     protected PackageDoc packageDoc;
 
     public PackageMatcher(PackageDoc packageDoc) {
-	super();
 	this.packageDoc = packageDoc;
     }
 

--- a/src/main/java/org/umlgraph/doclet/PackageView.java
+++ b/src/main/java/org/umlgraph/doclet/PackageView.java
@@ -77,5 +77,4 @@ public class PackageView implements OptionProvider {
 	if (!included || this.opt.matchesHideExpression(className))
 	    opt.setOption(HIDE);
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/PatternMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/PatternMatcher.java
@@ -14,6 +14,7 @@
  *
  *
  */
+
 package org.umlgraph.doclet;
 
 import java.util.regex.Pattern;
@@ -39,5 +40,4 @@ public class PatternMatcher implements ClassMatcher {
     public boolean matches(String name) {
 	return pattern.matcher(name).matches();
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/RelationDirection.java
+++ b/src/main/java/org/umlgraph/doclet/RelationDirection.java
@@ -36,5 +36,4 @@ public enum RelationDirection {
     public RelationDirection inverse() {
 	return this == IN ? OUT : this == OUT ? IN : this;
     }
-
-};
+}

--- a/src/main/java/org/umlgraph/doclet/RelationPattern.java
+++ b/src/main/java/org/umlgraph/doclet/RelationPattern.java
@@ -46,5 +46,4 @@ public class RelationPattern {
 	}
 	return false;
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/SubclassMatcher.java
+++ b/src/main/java/org/umlgraph/doclet/SubclassMatcher.java
@@ -32,5 +32,4 @@ public class SubclassMatcher implements ClassMatcher {
 	ClassDoc cd = root.classNamed(name);
 	return cd == null ? false : matches(cd);
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/UmlGraphDoc.java
+++ b/src/main/java/org/umlgraph/doclet/UmlGraphDoc.java
@@ -138,12 +138,12 @@ public class UmlGraphDoc {
       dotExecutable = "dot";
     }
 	File dotFile = new File(outputFolder, packageName.replace(".", "/") + "/" + name + ".dot");
-  File svgFile = new File(outputFolder, packageName.replace(".", "/") + "/" + name + ".svg");
+	File svgFile = new File(outputFolder, packageName.replace(".", "/") + "/" + name + ".svg");
 
 	try {
 	    Process p = Runtime.getRuntime().exec(new String [] {
 		dotExecutable,
-    "-Tsvg",
+		"-Tsvg",
 		"-o",
 		svgFile.getAbsolutePath(),
 		dotFile.getAbsolutePath()

--- a/src/main/java/org/umlgraph/doclet/View.java
+++ b/src/main/java/org/umlgraph/doclet/View.java
@@ -14,6 +14,7 @@
  *
  *
  */
+
 package org.umlgraph.doclet;
 
 import java.util.ArrayList;
@@ -169,5 +170,4 @@ public class View implements OptionProvider {
     public String getDisplayName() {
 	return "view " + viewDoc.name();
     }
-
 }

--- a/src/main/java/org/umlgraph/doclet/Visibility.java
+++ b/src/main/java/org/umlgraph/doclet/Visibility.java
@@ -16,6 +16,7 @@
  *
  *
  */
+
 package org.umlgraph.doclet;
 
 import com.sun.javadoc.ProgramElementDoc;

--- a/src/test/java/org/umlgraph/test/BasicTest.java
+++ b/src/test/java/org/umlgraph/test/BasicTest.java
@@ -58,13 +58,13 @@ public class BasicTest {
 	    for (String className : differences) {
 		pw.println(className);
 	    }
+            System.exit(1);
 	} else {
 	    pw.println("GOOD, all files are structurally equal");
 	}
 	pw.println();
 	pw.println();
 	pw.flush();
-	System.exit(differences.size() > 0 ? 1 : 0);
     }
 
     private static void performViewTests(List<String> differences, File outFolder)

--- a/src/test/java/org/umlgraph/test/BasicTest.java
+++ b/src/test/java/org/umlgraph/test/BasicTest.java
@@ -98,7 +98,7 @@ public class BasicTest {
     private static List<String> getViewList(File viewFolder) {
 	if (!viewFolder.exists())
 	    throw new RuntimeException("The folder " + viewFolder.getAbsolutePath()
-		    + " does not exists.");
+		    + " does not exist.");
 	else if (!viewFolder.isDirectory())
 	    throw new RuntimeException(viewFolder.getAbsolutePath() + " is not a folder!.");
 	else if (!viewFolder.canRead())

--- a/src/test/java/org/umlgraph/test/BasicTest.java
+++ b/src/test/java/org/umlgraph/test/BasicTest.java
@@ -145,5 +145,4 @@ public class BasicTest {
 	    differences.add(dotFile.getName() + " is different from the reference");
 	}
     }
-
 }

--- a/src/test/java/org/umlgraph/test/DotDiff.java
+++ b/src/test/java/org/umlgraph/test/DotDiff.java
@@ -304,5 +304,4 @@ public class DotDiff {
             return "Arc: " + from.label + " -> " + to.label + "; " + line;
         }
     }
-
 }

--- a/src/test/java/org/umlgraph/test/RunDoc.java
+++ b/src/test/java/org/umlgraph/test/RunDoc.java
@@ -43,5 +43,4 @@ public class RunDoc {
 	com.sun.tools.javadoc.Main.execute("UMLGraph test", pw, pw, pw,
 		"org.umlgraph.doclet.UmlGraphDoc", options);
     }
-
 }

--- a/src/test/java/org/umlgraph/test/RunOne.java
+++ b/src/test/java/org/umlgraph/test/RunOne.java
@@ -55,6 +55,4 @@ public class RunOne {
     private static void runDoclet(String[] options) {
 	com.sun.tools.javadoc.Main.execute("UMLGraph test", pw, pw, pw, "org.umlgraph.doclet.UmlGraph", options);
     }
-
-    
 }

--- a/src/test/java/org/umlgraph/test/SimpleFileFilter.java
+++ b/src/test/java/org/umlgraph/test/SimpleFileFilter.java
@@ -16,6 +16,7 @@
  *
  *
  */
+
 package org.umlgraph.test;
 
 import java.io.File;

--- a/src/test/java/org/umlgraph/test/TestUtils.java
+++ b/src/test/java/org/umlgraph/test/TestUtils.java
@@ -34,10 +34,10 @@ import java.util.List;
 public class TestUtils {
 
     /**
-         * Simple text file diffing: will tell you if two text files are line by
-         * line equals, and will stop at the first difference found.
-         * @throws IOException
-         */
+    * Simple text file diffing: will tell you if two text files are line by
+    * line equals, and will stop at the first difference found.
+    * @throws IOException
+    */
     public static boolean textFilesEquals(PrintWriter pw, File refTextFile, File outTextFile)
 	    throws IOException {
 	BufferedReader refReader = null, outReader = null;
@@ -123,8 +123,8 @@ public class TestUtils {
     }
 
     /**
-         * Deletes the content of the folder, eventually in a recursive way
-         */
+    * Deletes the content of the folder, eventually in a recursive way
+    */
     public static void cleanFolder(File folder, boolean recurse) {
 	for (File f : folder.listFiles()) {
 	    if (f.isDirectory()) {
@@ -138,7 +138,5 @@ public class TestUtils {
 	    }
 
 	}
-
     }
-
 }

--- a/src/test/java/org/umlgraph/test/TestUtils.java
+++ b/src/test/java/org/umlgraph/test/TestUtils.java
@@ -123,18 +123,17 @@ public class TestUtils {
     }
 
     /**
-         * Deletes the content of the folder, eventually in a recursive way (but
-         * avoids deleting eventual .cvsignore files and CVS folders)
+         * Deletes the content of the folder, eventually in a recursive way
          */
     public static void cleanFolder(File folder, boolean recurse) {
 	for (File f : folder.listFiles()) {
-	    if (f.isDirectory() && !f.getName().equals("CVS")) {
+	    if (f.isDirectory()) {
 		if (recurse) {
 		    cleanFolder(f, true);
 		    if (f.list().length == 0)
 			f.delete();
 		}
-	    } else if (!f.getName().equals(".cvsignore")) {
+	    } else {
 		f.delete();
 	    }
 

--- a/src/test/java/org/umlgraph/test/UmlDocTest.java
+++ b/src/test/java/org/umlgraph/test/UmlDocTest.java
@@ -16,6 +16,7 @@
  *
  *
  */
+
 package org.umlgraph.test;
 
 import java.io.File;
@@ -78,14 +79,14 @@ public class UmlDocTest {
     }
 
     /**
-         * Ensures that reference and output have the same contents in terms of:
-         * <ul>
-         * <li> html files </li>
-         * <li> dot files </li>
-         * <li> folders </li>
-         * </ul>
-         * @throws IOException
-         */
+    * Ensures that reference and output have the same contents in terms of:
+    * <ul>
+    * <li> html files </li>
+    * <li> dot files </li>
+    * <li> folders </li>
+    * </ul>
+    * @throws IOException
+    */
     private static void compareDocletOutputs(List<String> differences, File refFolder,
 	    File outFolder) throws IOException {
 	if (!refFolder.exists() || !refFolder.isDirectory())
@@ -139,9 +140,9 @@ public class UmlDocTest {
     }
 
     /**
-         * Runs the UmlGraphDoc doclet
-         * @param options
-         */
+    * Runs the UmlGraphDoc doclet
+    * @param options
+    */
     private static void runDoclet(String[] options) {
 	pw.print("Run javadoc -doclet " + doclet);
 	for (String o : options)
@@ -150,5 +151,4 @@ public class UmlDocTest {
 	com.sun.tools.javadoc.Main.execute("UMLDoc test", pw, pw, pw,
 		doclet, options);
     }
-
 }

--- a/src/test/java/org/umlgraph/test/UmlDocTest.java
+++ b/src/test/java/org/umlgraph/test/UmlDocTest.java
@@ -88,9 +88,6 @@ public class UmlDocTest {
          */
     private static void compareDocletOutputs(List<String> differences, File refFolder,
 	    File outFolder) throws IOException {
-	if(refFolder.getName().equals("CVS"))
-	    return;
-	
 	if (!refFolder.exists() || !refFolder.isDirectory())
 	    throw new IllegalArgumentException("Reference does not exist or is not a folder: "
 		    + refFolder.getAbsolutePath());

--- a/src/test/java/org/umlgraph/test/UmlDocTest.java
+++ b/src/test/java/org/umlgraph/test/UmlDocTest.java
@@ -145,11 +145,10 @@ public class UmlDocTest {
     private static void runDoclet(String[] options) {
 	pw.print("Run javadoc -doclet " + doclet);
 	for (String o : options)
-	    pw.print(" " + o);
+	    pw.print(o + " ");
 	pw.println();
 	com.sun.tools.javadoc.Main.execute("UMLDoc test", pw, pw, pw,
 		doclet, options);
-	System.exit(0);
     }
 
 }

--- a/src/test/java/org/umlgraph/test/UmlDocTest.java
+++ b/src/test/java/org/umlgraph/test/UmlDocTest.java
@@ -92,10 +92,10 @@ public class UmlDocTest {
 	    return;
 	
 	if (!refFolder.exists() || !refFolder.isDirectory())
-	    throw new IllegalArgumentException("Reference does not exists or is not a folder: "
+	    throw new IllegalArgumentException("Reference does not exist or is not a folder: "
 		    + refFolder.getAbsolutePath());
 	if (!outFolder.exists() || !outFolder.isDirectory())
-	    throw new IllegalArgumentException("Output does not exists or is not a folder: "
+	    throw new IllegalArgumentException("Output does not exist or is not a folder: "
 		    + outFolder.getAbsolutePath());
 
 	// get elements and sort


### PR DESCRIPTION
The majority is just about typos / formatting / rough edges.
Commit 0a71dbfc82dc7cfcfd888c0e46025bbcd69c6b27 undoes part of what 477d5cc58a2877d29ba1cf6bed5c9b4e868b5789 introduced, where UmlDocTest would exit (successfully) before comparing the doclet output to the reference. This unfortunately masked some failing tests (e.g. `testdata/umldoc-ref/gr/spinellis/invoice/gr.spinellis.invoice.dot`), where a class relation multiplicity does not appear. These tests now fail.