### PR TITLE
jdk9 migration fixes

### DIFF
--- a/src/main/java/org/umlgraph/doclet/ClassGraph.java
+++ b/src/main/java/org/umlgraph/doclet/ClassGraph.java
@@ -184,8 +184,7 @@ class ClassGraph {
                 }
                 if (i < typeParameters.size() - 1) {
                     genericsInfo += ", ";
-                }
-                if (i == typeParameters.size() - 1) {
+                } else if (i == typeParameters.size() - 1) {
                     genericsInfo += ">";
                 }
             }

--- a/src/main/java/org/umlgraph/doclet/UmlGraph.java
+++ b/src/main/java/org/umlgraph/doclet/UmlGraph.java
@@ -137,19 +137,21 @@ public class UmlGraph implements Doclet {
      */
     public static Options buildOptions(DocletEnvironment root, Options o) {
         commentOptions = o.clone();
-        commentOptions.setOptions(root.getDocTrees(), findClass(root, "UMLNoteOptions"));
+        commentOptions.setOptions(root.getDocTrees(), findClass(root, "UMLNoteOptions", false));
         commentOptions.shape = Shape.NOTE;
 
         Options opt = o.clone();
-        opt.setOptions(root.getDocTrees(), findClass(root, "UMLOptions"));
+        opt.setOptions(root.getDocTrees(), findClass(root, "UMLOptions", false));
         return opt;
     }
 
     /** Return the ClassDoc for the specified class; null if not found. */
-    private static TypeElement findClass(DocletEnvironment root, String name) {
+    private static TypeElement findClass(DocletEnvironment root, String name, boolean qualified) {
         Set<? extends Element> classes = root.getIncludedElements();
         for (Element element : classes) {
-            if (element instanceof TypeElement && ((TypeElement) element).getQualifiedName().toString().equals(name)) {
+            if (qualified && element instanceof TypeElement && ((TypeElement) element).getQualifiedName().toString().equals(name)) {
+                return (TypeElement) element;
+            } else if (!qualified && element instanceof TypeElement && element.getSimpleName().toString().equals(name)) {
                 return (TypeElement) element;
             }
         }
@@ -206,7 +208,7 @@ public class UmlGraph implements Doclet {
      */
     public static List<View> buildViews(Options opt, DocletEnvironment srcRootDoc, DocletEnvironment viewRootDoc) {
         if (opt.viewName != null) {
-            TypeElement viewClass = findClass(viewRootDoc, opt.viewName);
+            TypeElement viewClass = findClass(viewRootDoc, opt.viewName, true);
             if (viewClass == null) {
                 System.out.println("View " + opt.viewName + " not found! Exiting without generating any output.");
                 return null;

--- a/src/main/java/org/umlgraph/doclet/UmlGraphDoc.java
+++ b/src/main/java/org/umlgraph/doclet/UmlGraphDoc.java
@@ -122,8 +122,8 @@ public class UmlGraphDoc implements Doclet {
             } else {
                 continue;
             }
-            if (!packages.contains(packageDoc.getSimpleName())) {
-                packages.add(packageDoc.getSimpleName());
+            if (!packages.contains(packageDoc.getQualifiedName())) {
+                packages.add(packageDoc.getQualifiedName());
                 OptionProvider view = new PackageView(outputFolder, packageDoc, root, opt);
                 UmlGraph.buildGraph(reporter, root, opt, view, packageDoc);
                 runGraphviz(opt.dotExecutable, outputFolder, ElementUtil.getModuleOf(root, packageDoc), packageDoc.getQualifiedName(), packageDoc.getSimpleName(), reporter);

--- a/src/main/java/org/umlgraph/doclet/util/ElementUtil.java
+++ b/src/main/java/org/umlgraph/doclet/util/ElementUtil.java
@@ -15,6 +15,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -67,6 +68,9 @@ public class ElementUtil {
         Element element = types.asElement(t);
         if (element instanceof TypeElement) {
             return ((TypeElement) element).getQualifiedName();
+        }
+        if (element instanceof TypeVariable) {
+            return element.getSimpleName();
         }
         return "";
     }


### PR DESCRIPTION
2 fixes : 

- fix package generation which should use qualifiedName (compared to jdk8 `.name()` which points to full package name on packageElement)
- fix typevariable not printed on nodes